### PR TITLE
fix error in daily options variable

### DIFF
--- a/templates/yum-cron.conf.j2
+++ b/templates/yum-cron.conf.j2
@@ -78,7 +78,7 @@ mdpolicy = group:main
 
 # Uncomment to auto-import new gpg keys (dangerous)
 # assumeyes = True
-{% if daily_base_options is defined %}
+{% if yum_cron_daily_base_options is defined %}
 
 # Custom yum changes
 {% for option in yum_cron_daily_base_options %}


### PR DESCRIPTION
There was an error in the variable name.  The template (yum-cron.conf.j2) had the logic:

{% if daily_base_options is defined %}

But the actual variable is yum_cron_daily_base_options so the logic should be:

{% if yum_cron_daily_base_options is defined %}

This PR makes this change